### PR TITLE
Support guomi cert

### DIFF
--- a/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
@@ -37,6 +37,8 @@ public class CertTools {
     public static final String TYPE_AGENCY = "agency";
     public static final String TYPE_NODE = "node";
     public static final String TYPE_SDK = "sdk";
+    // 2019/12: support guomi
+    public static final String TYPE_ENCRYPT_NODE = "ennode";
     // 首次启动时需要拉取
     public static boolean isPullFrontCertsDone = false;
     /**
@@ -56,7 +58,7 @@ public class CertTools {
      * begin ...
      * end ...
      */
-    public static String addHeadAndTail(String certContent) {
+    public static String addCertHeadAndTail(String certContent) {
         String headToConcat = crtContentHead;
         String fullCert = headToConcat.concat(certContent).concat(crtTailForConcat);
         return fullCert;

--- a/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
@@ -45,11 +45,13 @@ public class CertTools {
      * 获取证书类型 和 名字
      * @return
      * @throws IOException
+     * //standard:
+     * //gm: CN=node0,O=fiscobcos,OU=agency
      */
-    public static String  getCertType(Principal subjectDN) {
+    public static String  getCertName(Principal subjectDN) {
         return subjectDN.toString().split(",")[0].split("=")[1];
     }
-    public static String  getCertName(Principal subjectDN) {
+    public static String  getCertType(Principal subjectDN) {
         return subjectDN.toString().split(",")[2].split("=")[1];
     }
 

--- a/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
@@ -37,9 +37,12 @@ public class CertTools {
     public static final String TYPE_CHAIN = "chain";
     public static final String TYPE_AGENCY = "agency";
     public static final String TYPE_NODE = "node";
-    public static final String TYPE_SDK = "sdk";
-    // 2019/12: support guomi
+    // 2019/12: support guomi, double cert mechanism
     public static final String TYPE_ENCRYPT_NODE = "ennode";
+    public static final String TYPE_SDK_CHAIN = "sdkca";
+    public static final String TYPE_SDK_AGENCY = "sdkagency";
+    // cert name: sdk ,type: node or sdk
+    public static final String TYPE_SDK_NODE = "sdknode";
     // 首次启动时需要拉取
     public static boolean isPullFrontCertsDone = false;
 

--- a/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/CertTools.java
@@ -18,6 +18,7 @@ package com.webank.webase.node.mgr.base.tools;
 
 import com.webank.webase.node.mgr.base.code.ConstantCode;
 import com.webank.webase.node.mgr.base.exception.NodeMgrException;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import org.fisco.bcos.web3j.crypto.Keys;
 import org.fisco.bcos.web3j.utils.Numeric;
 import sun.security.ec.ECPublicKeyImpl;
@@ -41,6 +42,9 @@ public class CertTools {
     public static final String TYPE_ENCRYPT_NODE = "ennode";
     // 首次启动时需要拉取
     public static boolean isPullFrontCertsDone = false;
+
+    // public key in hex length
+    public static final int PUBLIC_KEY_IN_HEX_LENGTH = 128;
     /**
      * 获取证书类型 和 名字
      * @return
@@ -72,20 +76,17 @@ public class CertTools {
      * @return String
      */
     public static String getPublicKeyString(PublicKey key) {
-        ECPublicKeyImpl pub = (ECPublicKeyImpl) key;
-        byte[] pubBytes = pub.getEncodedPublicValue();
-        String publicKey = Numeric.toHexStringNoPrefix(pubBytes);
-        publicKey = publicKey.substring(2); //证书byte[]为130位，只取128位，去除开头的04标记位
+        //        ECPublicKeyImpl pub = (ECPublicKeyImpl) key;
+        BCECPublicKey bcecPublicKey = (BCECPublicKey) key;
+        byte[] bcecPubBytes = bcecPublicKey.getEncoded();
+        String publicKey = Numeric.toHexStringNoPrefix(bcecPubBytes);
+        publicKey = publicKey.substring(publicKey.length() - PUBLIC_KEY_IN_HEX_LENGTH); //只取后128位
         return publicKey;
     }
 
     public static String getAddress(PublicKey key) {
-        ECPublicKeyImpl pub = (ECPublicKeyImpl) key;
-        byte[] pubBytes = pub.getEncodedPublicValue();
-        String publicKey = Numeric.toHexStringNoPrefix(pubBytes);
-        publicKey = publicKey.substring(2); //128位
-        String address = Keys.getAddress(publicKey);
-        return address;
+        String publicKey = getPublicKeyString(key);
+        return Keys.getAddress(publicKey);
     }
 
     // crt文件中默认首个是节点证书 0 isnode ca, 1 is agency ca, 2 is chain

--- a/src/main/java/com/webank/webase/node/mgr/base/tools/NodeMgrTools.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/NodeMgrTools.java
@@ -39,6 +39,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.fisco.bcos.web3j.crypto.EncryptType;
 import org.fisco.bcos.web3j.crypto.Hash;
+import org.fisco.bcos.web3j.utils.Numeric;
 
 /**
  * common method.
@@ -210,6 +211,25 @@ public class NodeMgrTools {
                 log.error("shaEncode getHashValue fail:", e);
                 return null;
             }
+        }
+    }
+
+    /**
+     * get x509 cert's fingerprint
+     * Hash using: SHA-1
+      * @param byteArray
+     * @return
+     */
+    public static String getCertFingerPrint(byte[] byteArray) {
+        byte[] hashResult;
+        MessageDigest sha = null;
+        try {
+            sha = MessageDigest.getInstance("SHA-1");
+            hashResult = sha.digest(byteArray);
+            return Numeric.toHexStringNoPrefix(hashResult).toUpperCase();
+        } catch (Exception e) {
+            log.error("shaEncode getCertFingerPrint fail:", e);
+            return null;
         }
     }
     /**

--- a/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
+++ b/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
@@ -92,7 +92,8 @@ public class CertService {
             String address = "";
             String fatherCertContent = "";
             // 非节点证书，无需公钥(RSA's public key)
-            if(CertTools.TYPE_NODE.equals(certType)) {
+            if(CertTools.TYPE_NODE.equals(certType) ||
+                    CertTools.TYPE_ENCRYPT_NODE.equals(certType)) {
                 // ECC 才有符合的public key, pub => address
                 publicKeyString = CertTools.getPublicKeyString(certImpl.getPublicKey());
                 address = Keys.getAddress(publicKeyString);

--- a/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
+++ b/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
@@ -91,9 +91,9 @@ public class CertService {
             String address = "";
             String fatherCertContent = "";
             // node cert has PublicKey and Address:
-            // standard: type=node;  guomi: type=encrypt_node, type=sdk&&name=sdk
+            // standard: type=node;  guomi: type = node || type=encrypt_node || type=sdk&&name=sdk
             if(CertTools.TYPE_NODE.equals(certType) || CertTools.TYPE_ENCRYPT_NODE.equals(certType) ||
-                    (CertTools.TYPE_SDK.equals(certType) && CertTools.TYPE_SDK.equals(certName))) {
+                    ("sdk".equals(certType) && "sdk".equals(certName))) {
                 // ECC 才有符合的public key, pub => address
                 publicKeyString = CertTools.getPublicKeyString(certImpl.getPublicKey());
                 address = Keys.getAddress(publicKeyString);
@@ -357,13 +357,19 @@ public class CertService {
         String nodeCertContent = certContents.get(CertTools.TYPE_NODE);
         // guomi encrypt node cert
         String encryptNodeCertContent = certContents.get(CertTools.TYPE_ENCRYPT_NODE);
-        String sdkCertContent = certContents.get(CertTools.TYPE_SDK);
+        String sdkChainCertContent = certContents.get(CertTools.TYPE_SDK_CHAIN);
+        String sdkAgencyCertContent = certContents.get(CertTools.TYPE_SDK_AGENCY);
+        String sdkNodeCertContent = certContents.get(CertTools.TYPE_SDK_NODE);
+        // fisco's cert
         handleSaveFrontCertStr(chainCertContent);
         handleSaveFrontCertStr(agencyCertContent);
         handleSaveFrontCertStr(nodeCertContent);
         handleSaveFrontCertStr(encryptNodeCertContent);
-        handleSaveFrontCertStr(sdkCertContent);
-        log.debug("end saveFrontCert. certContents:{} ");
+        //sdk's cert
+        handleSaveFrontCertStr(sdkChainCertContent);
+        handleSaveFrontCertStr(sdkAgencyCertContent);
+        handleSaveFrontCertStr(sdkNodeCertContent);
+        log.debug("end saveFrontCert. certContents. ");
     }
 
     /**
@@ -407,12 +413,13 @@ public class CertService {
      */
     public List<X509Certificate> loadCertListFromCrtContent(String crtContent) {
         log.debug("loadCertListFromCrtContent content:{}", crtContent);
-        List<X509Certificate> certs;
+        List<X509Certificate> certs = new ArrayList<>();
         try(InputStream is = new ByteArrayInputStream(crtContent.getBytes())) {
 
             org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory factory =
                     new org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory();
-            certs = (List<X509Certificate>) factory.engineGenerateCertificates(is).stream().collect(Collectors.toList());
+            factory.engineGenerateCertificates(is).stream()
+                    .forEach(c-> certs.add((X509Certificate)c));
 //            CertificateFactory cf = CertificateFactory.getInstance("X.509");
 //            certs = (List<X509Certificate>) cf.generateCertificates(is);
         }catch (CertificateException | IOException e) {

--- a/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
+++ b/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
@@ -25,6 +25,8 @@ import com.webank.webase.node.mgr.front.entity.FrontParam;
 import com.webank.webase.node.mgr.front.entity.TbFront;
 import com.webank.webase.node.mgr.frontinterface.FrontInterfaceService;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.fisco.bcos.web3j.crypto.EncryptType;
 import org.fisco.bcos.web3j.crypto.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -80,7 +82,7 @@ public class CertService {
             String certName = CertTools.getCertName(certImpl.getSubjectDN());
             String certType = CertTools.getCertType(certImpl.getSubjectDN());
             // 获取crt的原文,并加上头和尾
-            String certContent = CertTools.addHeadAndTail(certContentList.get(i));
+            String certContent = CertTools.addCertHeadAndTail(certContentList.get(i));
 
             // 判断证书类型后给pub和父子证书赋值
             String publicKeyString = "";
@@ -349,12 +351,15 @@ public class CertService {
         String chainCertContent = certContents.get(CertTools.TYPE_CHAIN);
         String agencyCertContent = certContents.get(CertTools.TYPE_AGENCY);
         String nodeCertContent = certContents.get(CertTools.TYPE_NODE);
+        // guomi encrypt node cert
+        String encryptNodeCertContent = certContents.get(CertTools.TYPE_ENCRYPT_NODE);
         String sdkCertContent = certContents.get(CertTools.TYPE_SDK);
         handleSaveFrontCertStr(chainCertContent);
         handleSaveFrontCertStr(agencyCertContent);
         handleSaveFrontCertStr(nodeCertContent);
+        handleSaveFrontCertStr(encryptNodeCertContent);
         handleSaveFrontCertStr(sdkCertContent);
-        log.debug("end saveFrontCert. certContents:{} ", certContents);
+        log.debug("end saveFrontCert. certContents:{} ");
     }
 
     /**
@@ -363,8 +368,8 @@ public class CertService {
      * @throws CertificateException
      */
     public void handleSaveFrontCertStr(String certStr) throws CertificateException {
-        if(!"".equals(certStr)) {
-            certStr = CertTools.addHeadAndTail(certStr);
+        if(StringUtils.isNotEmpty(certStr)) {
+            certStr = CertTools.addCertHeadAndTail(certStr);
             log.debug("start handleSaveFrontCertStr:{} ", certStr);
             saveCerts(certStr);
             log.debug("end handleSaveFrontCertStr:{} ", certStr);

--- a/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
+++ b/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 
 import java.io.InputStream;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
+++ b/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
@@ -409,14 +409,12 @@ public class CertService {
         log.debug("loadCertListFromCrtContent content:{}", crtContent);
         List<X509Certificate> certs;
         try(InputStream is = new ByteArrayInputStream(crtContent.getBytes())) {
-            if(EncryptType.encryptType == 1) {
-                org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory factory =
-                        new org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory();
-                certs = (List<X509Certificate>) factory.engineGenerateCertificates(is).stream().collect(Collectors.toList());
-            } else {
-                CertificateFactory cf = CertificateFactory.getInstance("X.509");
-                certs = (List<X509Certificate>) cf.generateCertificates(is);
-            }
+
+            org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory factory =
+                    new org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory();
+            certs = (List<X509Certificate>) factory.engineGenerateCertificates(is).stream().collect(Collectors.toList());
+//            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+//            certs = (List<X509Certificate>) cf.generateCertificates(is);
         }catch (CertificateException | IOException e) {
             log.error("loadCertListFromCrtContent exception:[]", e);
             throw new NodeMgrException(ConstantCode.CERT_ERROR.getCode(), e.getMessage());
@@ -429,15 +427,9 @@ public class CertService {
         log.debug("start loadSingleCertFromCrtContent. content:{}", crtContent);
         X509Certificate cert;
         try(InputStream is = new ByteArrayInputStream(crtContent.getBytes())) {
-            if(EncryptType.encryptType == 1) {
-                org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory factory =
-                        new org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory();
-                cert = (X509Certificate) factory.engineGenerateCertificate(is);
-            } else {
-                CertificateFactory cf = CertificateFactory.getInstance("X.509");
-                cert = (X509Certificate) cf.generateCertificate(is);
-            }
-
+            org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory factory =
+                    new org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory();
+            cert = (X509Certificate) factory.engineGenerateCertificate(is);
         }catch (CertificateException | IOException e) {
             log.error("get loadSingleCertFromCrtContent. Exception:[]", e);
             throw new NodeMgrException(ConstantCode.CERT_ERROR.getCode(), e.getMessage());

--- a/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
+++ b/src/main/java/com/webank/webase/node/mgr/cert/CertService.java
@@ -91,9 +91,10 @@ public class CertService {
             String publicKeyString = "";
             String address = "";
             String fatherCertContent = "";
-            // 非节点证书，无需公钥(RSA's public key)
-            if(CertTools.TYPE_NODE.equals(certType) ||
-                    CertTools.TYPE_ENCRYPT_NODE.equals(certType)) {
+            // node cert has PublicKey and Address:
+            // standard: type=node;  guomi: type=encrypt_node, type=sdk&&name=sdk
+            if(CertTools.TYPE_NODE.equals(certType) || CertTools.TYPE_ENCRYPT_NODE.equals(certType) ||
+                    (CertTools.TYPE_SDK.equals(certType) && CertTools.TYPE_SDK.equals(certName))) {
                 // ECC 才有符合的public key, pub => address
                 publicKeyString = CertTools.getPublicKeyString(certImpl.getPublicKey());
                 address = Keys.getAddress(publicKeyString);

--- a/src/main/java/com/webank/webase/node/mgr/node/NodeService.java
+++ b/src/main/java/com/webank/webase/node/mgr/node/NodeService.java
@@ -47,7 +47,8 @@ public class NodeService {
     private NodeMapper nodeMapper;
     @Autowired
     private FrontInterfaceService frontInterface;
-    private static final Long CHECK_NODE_WAIT_MIN_MILLIS = 5000L;
+    // interval of check node status
+    private static final Long CHECK_NODE_WAIT_MIN_MILLIS = 7500L;
 
     /**
      * add new node data.
@@ -188,6 +189,7 @@ public class NodeService {
 
     /**
      * check node status
+     *
      */
     public void checkAndUpdateNodeStatus(int groupId) {
         //get local node list
@@ -230,6 +232,7 @@ public class NodeService {
                 .orElse(BigInteger.ZERO);//pbftView
             
             if (nodeType == 0) {    //0-consensus;1-observer
+                // if local block number and pbftView equals chain's, invalid
                 if (localBlockNumber.equals(latestNumber) && localPbftView.equals(latestView)) {
                     log.warn("node[{}] is invalid. localNumber:{} chainNumber:{} localView:{} chainView:{}",
                         nodeId, localBlockNumber, latestNumber, localPbftView, latestView);
@@ -240,6 +243,7 @@ public class NodeService {
                     tbNode.setNodeActive(DataStatus.NORMAL.getValue());
                 }
             } else { //observer
+                // if latest block number not equal, invalid
                 if (!latestNumber.equals(frontInterface.getLatestBlockNumber(groupId))) {
                     log.warn("node[{}] is invalid. localNumber:{} chainNumber:{} localView:{} chainView:{}",
                             nodeId, localBlockNumber, latestNumber, localPbftView, latestView);
@@ -250,7 +254,7 @@ public class NodeService {
                     tbNode.setNodeActive(DataStatus.NORMAL.getValue());
                 }
             }
-
+            tbNode.setModifyTime(LocalDateTime.now());
             //update node
             updateNode(tbNode);
         }

--- a/src/test/java/node/mgr/test/alert/mail/SendMailTest.java
+++ b/src/test/java/node/mgr/test/alert/mail/SendMailTest.java
@@ -60,9 +60,9 @@ public class SendMailTest {
 
     /**
      * test alert_rule
-     * INSERT INTO `tb_alert_rule`(`rule_name`,`enable`,`alert_type`,`alert_level`,`alert_interval`,`alert_content`,`content_param_list`,`description`,`is_all_user`,`user_list`,`create_time`,`modify_time`,`less_than`,`less_and_equal`,`larger_than`,`larger_and_equal`,`equal`)VALUES ('测试告警', 0, 2, 'low', 3600, '这是测试邮件，来自from', '["from"]', '', 0, '["15889463195@163.com", "g120856@126.com"]', '2019-10-29 20:02:30', '2019-10-29 20:02:30', '','','','','');
+     * INSERT INTO `tb_alert_rule`(`rule_name`,`enable`,`alert_type`,`alert_level`,`alert_interval`,`alert_content`,`content_param_list`,`description`,`is_all_user`,`user_list`,`create_time`,`modify_time`,`less_than`,`less_and_equal`,`larger_than`,`larger_and_equal`,`equal`)VALUES ('测试告警', 0, 2, 'low', 3600, '这是测试邮件，来自from', '["from"]', '', 0, '["15889463195@163.com"]', '2019-10-29 20:02:30', '2019-10-29 20:02:30', '','','','','');
      * test mail_server_config
-     * INSERT INTO `tb_mail_server_config`(`server_name`,`host`,`username`,`password`,`protocol`,`default_encoding`,`create_time`,`modify_time`,`authentication`,`starttls_enable`,`starttls_required`,`socket_factory_port`,`socket_factory_class`,`socket_factory_fallback`) VALUES ('Default config', 'smtp.163.com', '15889463195@163.com', 'youlin123456','smtp', 'UTF-8','2019-10-29 20:02:30', '2019-10-29 20:02:30', 1, 1, 0, 465, 'javax.net.ssl.SSLSocketFactory', 0);     *
+     * INSERT INTO `tb_mail_server_config`(`server_name`,`host`,`username`,`password`,`protocol`,`default_encoding`,`create_time`,`modify_time`,`authentication`,`starttls_enable`,`starttls_required`,`socket_factory_port`,`socket_factory_class`,`socket_factory_fallback`) VALUES ('Default config', 'smtp.163.com', '15889463195@163.com', '','smtp', 'UTF-8','2019-10-29 20:02:30', '2019-10-29 20:02:30', 1, 1, 0, 465, 'javax.net.ssl.SSLSocketFactory', 0);     *
      */
     @Test
     public void testSendingByRule() {

--- a/src/test/java/node/mgr/test/cert/BCCertTest.java
+++ b/src/test/java/node/mgr/test/cert/BCCertTest.java
@@ -19,10 +19,16 @@ package node.mgr.test.cert;
 import com.webank.webase.node.mgr.base.tools.CertTools;
 import com.webank.webase.node.mgr.base.tools.NodeMgrTools;
 import io.jsonwebtoken.lang.Assert;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+import org.fisco.bcos.web3j.utils.Numeric;
 import org.junit.Test;
+import sun.security.ec.ECPublicKeyImpl;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
@@ -41,6 +47,20 @@ public class BCCertTest {
     public final static String standardNodeCrt = "MIICOTCCASGgAwIBAgIJAKHsAYI3TsAOMA0GCSqGSIb3DQEBCwUAMDgxEDAOBgNV\nBAMMB2FnZW5jeUExEzARBgNVBAoMCmZpc2NvLWJjb3MxDzANBgNVBAsMBmFnZW5j\neTAeFw0xOTA3MTIwMjA2MTZaFw0yOTA3MDkwMjA2MTZaMDIxDDAKBgNVBAMMA3Nk\nazETMBEGA1UECgwKZmlzY28tYmNvczENMAsGA1UECwwEbm9kZTBWMBAGByqGSM49\nAgEGBSuBBAAKA0IABJ79rSKIb97xZwByW58xH6tzoNKNLaKG7J5wxAEgAb03O2h4\nMkEMLtf/LB7tELOiyCiIEhLScprb1LjvDDt2RDGjGjAYMAkGA1UdEwQCMAAwCwYD\nVR0PBAQDAgXgMA0GCSqGSIb3DQEBCwUAA4IBAQC0u2lfclRmCszBTi2rtvMibZec\noalRC0sQPBPRb7UQhGCodxmsAT3dBUf+s4wLLrmN/cnNhq5HVObbWxzfu7gn3+IN\nyQEeqdbGdzlu1EDcaMgAz6p2W3+FG/tmx/yrNza29cYekWRL44OT5LOUPEKrJ4bJ\neOBRY4QlwZPFmM0QgP7DoKxHXldRopkmvqT4pbW51hWvPgj7KrdqwbVWzuWQuI3i\n3j3O96XZJsaDZ0+IGa5093+TsTNPfWUZzp5Kg+EyNR6Ea1evuMDNq9NAqqcd5bX9\nO9kgkb8+llO8I5ZhdnN0BuhGvv9wpsa9hW8BImOLzUBwfSVYouGCkoqlVq9X";
     public final static String standardAgencyCrt = "MIIDADCCAeigAwIBAgIJAJUF2Dp1a9U6MA0GCSqGSIb3DQEBCwUAMDUxDjAMBgNV\nBAMMBWNoYWluMRMwEQYDVQQKDApmaXNjby1iY29zMQ4wDAYDVQQLDAVjaGFpbjAe\nFw0xOTA3MTIwMjA2MTZaFw0yOTA3MDkwMjA2MTZaMDgxEDAOBgNVBAMMB2FnZW5j\neUExEzARBgNVBAoMCmZpc2NvLWJjb3MxDzANBgNVBAsMBmFnZW5jeTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBANBT4CTciIYdSeEabgJzif+CFB0y3GzG\ny+XQYtWK+TtdJWduXqhnnZiYAZs7OPGEu79Yx/bEpjEXsu2cXH0D6BHZk+wvuxG6\nezXWq5MYjCw3fQiSRWkDYoxzWgulkRyYROF1xoZeNGQssReFmCgP+pcQwRxjcq8z\nIA9iT61YxyW5nrS7xnra9uZq/EE3tsJ0ae3ax6zixCT66aV49S27cMcisS+XKP/q\nEVPxhO7SUjnzZY69MgZzNSFxCzIbapnlmYAOS26vIT0taSkoKXmIsYssga45XPwI\n7YBVCc/34kHzW9xrNjyyThMWOgDsuBqZN9xvapGSQ82Lsh7ObN0dZVUCAwEAAaMQ\nMA4wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAu3aHxJnCZnICpHbQ\nv1Lc5tiXtAYE9aEP5cxb/cO14xY8dS+t0wiLIvyrE2aTcgImzr4BYNBm1XDt5suc\nMpzha1oJytGv79M9/WnI/BKmgUqTaaXOV2Ux2yPX9SadNcsD9/IbrV0b/hlsPd6M\nK8w7ndowvBgopei+A1NQY6jTDUKif4RxD4u5HZFWUu7pByNLFaydU4qBKVkucXOq\nxmWoupL5XrDk5o490kiz/Zgufqtb4w6oUr3lrQASAbFB3lID/P1ipi0DwX7kZwVX\nECDLYvr+eX6GbTClzn0JGuzqV4OoRo1rrRv+0tp1aLZKpCYn0Lhf6s1iw/kCeM2O\nnP9l2Q==";
     public final static String standardChainCrt = "MIIDPTCCAiWgAwIBAgIJAMfvnu4d5fHdMA0GCSqGSIb3DQEBCwUAMDUxDjAMBgNV\nBAMMBWNoYWluMRMwEQYDVQQKDApmaXNjby1iY29zMQ4wDAYDVQQLDAVjaGFpbjAe\nFw0xOTA3MTIwMjA2MTZaFw0yOTA3MDkwMjA2MTZaMDUxDjAMBgNVBAMMBWNoYWlu\nMRMwEQYDVQQKDApmaXNjby1iY29zMQ4wDAYDVQQLDAVjaGFpbjCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBAMGsKT/S60cxvFS4tBLyfT0QKPLW1g3ZgMND\n03hrWp1FAnvE9htsDEgqvNLD5hKWaYcUhjQMq0WttiP/vPxkwwJkZhzWhXpdSxMR\nqKVX4BppnkT0ICm84jYSyJdNFjKvfWlBIptIfFuTUDMT+XqF/Ct756JksiUwKZRW\neRAVcYzFM4u4ZuKeaept/8Bv8Z/RlJzGI57qj5BELeA0meUagq2WoCgJrPyvbO0b\nLwogFWS4kEjv20IIdj3fTqeJlooEXtPnuegunSMQB6aIh2im74FfJ3sHuOjQDFuC\nb5ZUiyUHG6IOGCqs+Grk+/VYI16Mx+8OoGBD5koTpK8B+/aedsUCAwEAAaNQME4w\nHQYDVR0OBBYEFLTg2FsUFekx9XjIi01BrDpo0aPIMB8GA1UdIwQYMBaAFLTg2FsU\nFekx9XjIi01BrDpo0aPIMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB\nAJmuMLhWSld8G6i3Vw21TN/d2rSRg3hNqOyycPYtdVK1YXEj4Xm91qgL8An3Kui8\njSq1S9+PstGvyh14YUw43Y1VtEPGpNVTvDtkxQ/8rs1sGHbqUxshgFMbqruxp7WH\ns0fxgn5COHEnRC4jQn02wZAk8pIjFVZLkhqdIYBtC35buHr17mXNL0S4H5cJxzPN\nk3XtKBqXedkTrEsDhR/bZ6qDDq0BcduhtKiYVPiVw9z3moLuwDb0QDM59zCexpcz\nb/w7K4lIxWqpD5tbpKSmj/3v5TCqez0Mim8/j4q29bP913KQrngnVCdCezOsPWIH\nDDoihgeRQHuz1VuGGZ259Hc=";
+
+    //guomi's sdk cert is not guomi
+    public final static String gmSdkCrt = "MIICNzCCAR+gAwIBAgIJAOCh/7JoVFs3MA0GCSqGSIb3DQEBCwUAMDcxDzANBgNV\n" +
+            "BAMMBmFnZW5jeTETMBEGA1UECgwKZmlzY28tYmNvczEPMA0GA1UECwwGYWdlbmN5\n" +
+            "MB4XDTE5MTEyNTAzNDExMVoXDTI5MTEyMjAzNDExMVowMTEMMAoGA1UEAwwDc2Rr\n" +
+            "MRMwEQYDVQQKDApmaXNjby1iY29zMQwwCgYDVQQLDANzZGswVjAQBgcqhkjOPQIB\n" +
+            "BgUrgQQACgNCAAR4U4lvTksIkcWVTVs/dzJeOXIHGOyOGlYI5Oh3S92w3N1jqY2t\n" +
+            "bCdmAxc2dMR38iaeersee4sem5yFLCetfAgUoxowGDAJBgNVHRMEAjAAMAsGA1Ud\n" +
+            "DwQEAwIF4DANBgkqhkiG9w0BAQsFAAOCAQEAr6Frxn/pLNnG3aRV+aGulXXS7kYr\n" +
+            "Tc6CIZ8O+2m758+A3rWN6GHuKEZ0kYy/h2vYjpgpezVXRElmuON/LbyX+hvBXtxY\n" +
+            "aAaTFR/OLiCJ6UiRISSnRRbvl6nClmHeZjf4gddvEqAxicKGGWxmek2FXDzxvA11\n" +
+            "h4vfNEnxatLqtlM5hSZkNIYrYCiSaXFE0w2UB4uuIoLrcfE+YR4nYxISNdSKpYjh\n" +
+            "BXwVuJgMRaQXI4njL4Rd6X+f7wA6lBJBMPmj+YWHdWTQCpUOe5yYxj7o7yEPtmJr\n" +
+            "MqZAO+R9xoTWsifsjHyD3AuUxd3bQBqojih4C89tvtww+4FDzmnC3R/4pg==";
 
     /**
      * 加载国密证书，并打印指纹
@@ -101,6 +121,34 @@ public class BCCertTest {
         }
     }
 
+    @Test
+    public void testGmCertPublicKey() throws CertificateException {
+        String crtContent = CertTools.addCertHeadAndTail(standardNodeCrt);
+        InputStream is2 = new ByteArrayInputStream(crtContent.getBytes());
+        CertificateFactory factory = new CertificateFactory();
+        X509Certificate certificate = (X509Certificate)factory.engineGenerateCertificate(is2);
+        BCECPublicKey bcecPublicKey = (BCECPublicKey) certificate.getPublicKey();
+        System.out.println(bcecPublicKey.getEncoded());
+        byte[] bcecPubBytes = bcecPublicKey.getEncoded();
+        String publicKeyBC = Numeric.toHexStringNoPrefix(bcecPubBytes);
+        publicKeyBC = publicKeyBC.substring(publicKeyBC.length() - 128); //证书byte[]为130位，只取128位，去除开头的04标记位
+        System.out.println(publicKeyBC); // 3056301006072a8648ce3d020106052b8104000a034200047853896f4e4b0891c5954d5b3f77325e39720718ec8e1a5608e4e8774bddb0dcdd63a98dad6c276603173674c477f2269e7abb1e7b8b1e9b9c852c27ad7c0814
 
+        //========== import java.security.cert.CertificateFactory;
+        /** @Deprecated */
+        InputStream is = new ByteArrayInputStream(crtContent.getBytes());
+        java.security.cert.CertificateFactory cf = java.security.cert.CertificateFactory.getInstance("X.509");
+        X509Certificate cert2 = (X509Certificate) cf.generateCertificate(is);
+        PublicKey publicKeyObject = cert2.getPublicKey();
+        // this.key = ECUtil.encodePoint(var1, var2.getCurve());
+        ECPublicKeyImpl pub = (ECPublicKeyImpl) publicKeyObject;
+        byte[] pubBytes = pub.getEncodedPublicValue();
+        String publicKey = Numeric.toHexStringNoPrefix(pubBytes);
+        publicKey = publicKey.substring(publicKey.length() - 128); //证书byte[]为130位，只取128位，去除开头的04标记位
+        System.out.println(publicKey);// 7853896f4e4b0891c5954d5b3f77325e39720718ec8e1a5608e4e8774bddb0dcdd63a98dad6c276603173674c477f2269e7abb1e7b8b1e9b9c852c27ad7c0814
+
+        Assert.isTrue(publicKeyBC.equals(publicKey));
+        Assert.isTrue(publicKeyBC.equals(CertTools.getPublicKeyString(bcecPublicKey)));
+    }
 
 }

--- a/src/test/java/node/mgr/test/cert/BCCertTest.java
+++ b/src/test/java/node/mgr/test/cert/BCCertTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2014-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package node.mgr.test.cert;
+
+import com.webank.webase.node.mgr.base.tools.CertTools;
+import com.webank.webase.node.mgr.base.tools.NodeMgrTools;
+import io.jsonwebtoken.lang.Assert;
+import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
+import org.junit.Test;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import java.util.List;
+
+
+
+/**
+ * factory: org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory
+ * instance: java.security.cert.X509Certificate
+ * replace java.security.X509.X509CertImpl which is deprecated
+ */
+public class BCCertTest {
+
+    public final static String gmNodeCrt = "MIIBfDCCASKgAwIBAgIJAI98D486PmWFMAoGCCqBHM9VAYN1MDYxDzANBgNVBAMM\nBmFnZW5jeTESMBAGA1UECgwJZmlzY29iY29zMQ8wDQYDVQQLDAZhZ2VuY3kwHhcN\nMTkxMTI1MDM0MTExWhcNMjkxMTIyMDM0MTExWjA1MQ4wDAYDVQQDDAVub2RlMDES\nMBAGA1UECgwJZmlzY29iY29zMQ8wDQYDVQQLDAZhZ2VuY3kwWTATBgcqhkjOPQIB\nBggqgRzPVQGCLQNCAAS0TE9xO0C2ftL52uLvIIgIt/MREu/hqCLeBGYE/gu9/99G\nt8DPHKmqRodS1RSVjLYDZwptNFx4+v9uadgl6FG4oxowGDAJBgNVHRMEAjAAMAsG\nA1UdDwQEAwIGwDAKBggqgRzPVQGDdQNIADBFAiEAqF6J+H31mW0vcbGxFBjAM2Ue\n9GFZNrpS5UjFRDxFAcsCIFuzUNWBo/y1ySxSftxBFPd5I/iHedSFKPybcxQilvqt";
+    public final static String standardNodeCrt = "MIICOTCCASGgAwIBAgIJAKHsAYI3TsAOMA0GCSqGSIb3DQEBCwUAMDgxEDAOBgNV\nBAMMB2FnZW5jeUExEzARBgNVBAoMCmZpc2NvLWJjb3MxDzANBgNVBAsMBmFnZW5j\neTAeFw0xOTA3MTIwMjA2MTZaFw0yOTA3MDkwMjA2MTZaMDIxDDAKBgNVBAMMA3Nk\nazETMBEGA1UECgwKZmlzY28tYmNvczENMAsGA1UECwwEbm9kZTBWMBAGByqGSM49\nAgEGBSuBBAAKA0IABJ79rSKIb97xZwByW58xH6tzoNKNLaKG7J5wxAEgAb03O2h4\nMkEMLtf/LB7tELOiyCiIEhLScprb1LjvDDt2RDGjGjAYMAkGA1UdEwQCMAAwCwYD\nVR0PBAQDAgXgMA0GCSqGSIb3DQEBCwUAA4IBAQC0u2lfclRmCszBTi2rtvMibZec\noalRC0sQPBPRb7UQhGCodxmsAT3dBUf+s4wLLrmN/cnNhq5HVObbWxzfu7gn3+IN\nyQEeqdbGdzlu1EDcaMgAz6p2W3+FG/tmx/yrNza29cYekWRL44OT5LOUPEKrJ4bJ\neOBRY4QlwZPFmM0QgP7DoKxHXldRopkmvqT4pbW51hWvPgj7KrdqwbVWzuWQuI3i\n3j3O96XZJsaDZ0+IGa5093+TsTNPfWUZzp5Kg+EyNR6Ea1evuMDNq9NAqqcd5bX9\nO9kgkb8+llO8I5ZhdnN0BuhGvv9wpsa9hW8BImOLzUBwfSVYouGCkoqlVq9X";
+    public final static String standardAgencyCrt = "MIIDADCCAeigAwIBAgIJAJUF2Dp1a9U6MA0GCSqGSIb3DQEBCwUAMDUxDjAMBgNV\nBAMMBWNoYWluMRMwEQYDVQQKDApmaXNjby1iY29zMQ4wDAYDVQQLDAVjaGFpbjAe\nFw0xOTA3MTIwMjA2MTZaFw0yOTA3MDkwMjA2MTZaMDgxEDAOBgNVBAMMB2FnZW5j\neUExEzARBgNVBAoMCmZpc2NvLWJjb3MxDzANBgNVBAsMBmFnZW5jeTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBANBT4CTciIYdSeEabgJzif+CFB0y3GzG\ny+XQYtWK+TtdJWduXqhnnZiYAZs7OPGEu79Yx/bEpjEXsu2cXH0D6BHZk+wvuxG6\nezXWq5MYjCw3fQiSRWkDYoxzWgulkRyYROF1xoZeNGQssReFmCgP+pcQwRxjcq8z\nIA9iT61YxyW5nrS7xnra9uZq/EE3tsJ0ae3ax6zixCT66aV49S27cMcisS+XKP/q\nEVPxhO7SUjnzZY69MgZzNSFxCzIbapnlmYAOS26vIT0taSkoKXmIsYssga45XPwI\n7YBVCc/34kHzW9xrNjyyThMWOgDsuBqZN9xvapGSQ82Lsh7ObN0dZVUCAwEAAaMQ\nMA4wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAu3aHxJnCZnICpHbQ\nv1Lc5tiXtAYE9aEP5cxb/cO14xY8dS+t0wiLIvyrE2aTcgImzr4BYNBm1XDt5suc\nMpzha1oJytGv79M9/WnI/BKmgUqTaaXOV2Ux2yPX9SadNcsD9/IbrV0b/hlsPd6M\nK8w7ndowvBgopei+A1NQY6jTDUKif4RxD4u5HZFWUu7pByNLFaydU4qBKVkucXOq\nxmWoupL5XrDk5o490kiz/Zgufqtb4w6oUr3lrQASAbFB3lID/P1ipi0DwX7kZwVX\nECDLYvr+eX6GbTClzn0JGuzqV4OoRo1rrRv+0tp1aLZKpCYn0Lhf6s1iw/kCeM2O\nnP9l2Q==";
+    public final static String standardChainCrt = "MIIDPTCCAiWgAwIBAgIJAMfvnu4d5fHdMA0GCSqGSIb3DQEBCwUAMDUxDjAMBgNV\nBAMMBWNoYWluMRMwEQYDVQQKDApmaXNjby1iY29zMQ4wDAYDVQQLDAVjaGFpbjAe\nFw0xOTA3MTIwMjA2MTZaFw0yOTA3MDkwMjA2MTZaMDUxDjAMBgNVBAMMBWNoYWlu\nMRMwEQYDVQQKDApmaXNjby1iY29zMQ4wDAYDVQQLDAVjaGFpbjCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBAMGsKT/S60cxvFS4tBLyfT0QKPLW1g3ZgMND\n03hrWp1FAnvE9htsDEgqvNLD5hKWaYcUhjQMq0WttiP/vPxkwwJkZhzWhXpdSxMR\nqKVX4BppnkT0ICm84jYSyJdNFjKvfWlBIptIfFuTUDMT+XqF/Ct756JksiUwKZRW\neRAVcYzFM4u4ZuKeaept/8Bv8Z/RlJzGI57qj5BELeA0meUagq2WoCgJrPyvbO0b\nLwogFWS4kEjv20IIdj3fTqeJlooEXtPnuegunSMQB6aIh2im74FfJ3sHuOjQDFuC\nb5ZUiyUHG6IOGCqs+Grk+/VYI16Mx+8OoGBD5koTpK8B+/aedsUCAwEAAaNQME4w\nHQYDVR0OBBYEFLTg2FsUFekx9XjIi01BrDpo0aPIMB8GA1UdIwQYMBaAFLTg2FsU\nFekx9XjIi01BrDpo0aPIMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB\nAJmuMLhWSld8G6i3Vw21TN/d2rSRg3hNqOyycPYtdVK1YXEj4Xm91qgL8An3Kui8\njSq1S9+PstGvyh14YUw43Y1VtEPGpNVTvDtkxQ/8rs1sGHbqUxshgFMbqruxp7WH\ns0fxgn5COHEnRC4jQn02wZAk8pIjFVZLkhqdIYBtC35buHr17mXNL0S4H5cJxzPN\nk3XtKBqXedkTrEsDhR/bZ6qDDq0BcduhtKiYVPiVw9z3moLuwDb0QDM59zCexpcz\nb/w7K4lIxWqpD5tbpKSmj/3v5TCqez0Mim8/j4q29bP913KQrngnVCdCezOsPWIH\nDDoihgeRQHuz1VuGGZ259Hc=";
+
+    /**
+     * 加载国密证书，并打印指纹
+     * @throws CertificateException
+     */
+    @Test
+    public void testCertFingerprint() throws CertificateException {
+        String cert = CertTools.addCertHeadAndTail(gmNodeCrt);
+        // print fingerprint
+        loadCert(new ByteArrayInputStream(cert.getBytes()));
+    }
+
+    /**
+     * get guomi cert, use bouncy castle
+     * @param is
+     * @throws CertificateException
+     */
+    private void loadCert(InputStream is) throws CertificateException {
+        CertificateFactory factory = new CertificateFactory();
+        X509Certificate cert = (X509Certificate) factory.engineGenerateCertificate(is);
+        System.out.println(cert.getType());
+        System.out.println(cert.getPublicKey());
+        System.out.println(cert.getSubjectDN());
+        System.out.println("guomi node fingerPrint");
+        String fingerPrint = NodeMgrTools.getCertFingerPrint(cert.getEncoded());
+        System.out.println(fingerPrint);
+        Assert.notNull(fingerPrint);
+    }
+
+    @Test
+    public void getCertContent() {
+        String certCa = CertTools.addCertHeadAndTail(standardChainCrt);
+        String certAgency = CertTools.addCertHeadAndTail(standardAgencyCrt);
+        String certNode = CertTools.addCertHeadAndTail(standardNodeCrt);
+        System.out.println("===getCertContent");
+        System.out.println(certCa);
+        System.out.println(certAgency);
+        System.out.println(certNode);
+    }
+
+    /**
+     * use sun.security 获取指纹 限定 非国密 cert
+     */
+    @Test
+    public void getCertFingerPrint() throws CertificateException {
+        java.security.cert.CertificateFactory cf = java.security.cert.CertificateFactory.getInstance("X.509");
+        String cert = CertTools.addCertHeadAndTail(standardNodeCrt);
+        System.out.println(cert);
+        // guomi's EC curve not match X509CertImpl
+        List<X509Certificate> certs = (List<X509Certificate>) cf.generateCertificates(new ByteArrayInputStream(cert.getBytes()));
+        Assert.notNull(certs);
+
+        if (certs.size() != 0) {
+            System.out.println("===standard cert");
+            System.out.println("SHA-1 fingerPrint");
+            System.out.println(NodeMgrTools.getCertFingerPrint(certs.get(0).getEncoded()));
+
+        }
+    }
+
+
+
+}

--- a/src/test/java/node/mgr/test/cert/ImportCertTest.java
+++ b/src/test/java/node/mgr/test/cert/ImportCertTest.java
@@ -20,7 +20,9 @@ import java.security.*;
 import java.security.cert.*;
 import java.util.*;
 
+import com.webank.webase.node.mgr.base.tools.CertTools;
 import com.webank.webase.node.mgr.base.tools.NodeMgrTools;
+import io.jsonwebtoken.lang.Assert;
 import org.fisco.bcos.web3j.crypto.ECKeyPair;
 import org.fisco.bcos.web3j.crypto.Keys;
 import org.fisco.bcos.web3j.utils.Numeric;
@@ -31,7 +33,11 @@ import sun.security.ec.ECPublicKeyImpl;
 import static com.webank.webase.node.mgr.base.tools.CertTools.byteToHex;
 
 /**
- * test load non-guomi cert
+ * test load non-guomi cert and guomi cert
+ * using java.security.cert.CertificateFactory getInstance("X.509");
+ * 2019/12
+ * replace java.security.cert.CertificateFactory
+ * with org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory
  */
 public class ImportCertTest {
     private final static String head = "-----BEGIN CERTIFICATE-----\n" ;
@@ -184,5 +190,27 @@ public class ImportCertTest {
             System.out.println("Error checking Certificate Validity.  See admin.");
             return true;
         }
+    }
+
+    /**
+     * import guomi node cert list
+     * @throws CertificateEncodingException
+     */
+    @Test
+    public void testLoadCertList() throws CertificateException, IOException {
+        // need gmnode.crt file
+        InputStream nodes = new ClassPathResource("notgmnode.crt").getInputStream();
+        org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory factory =
+                new org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory();
+        List<X509Certificate> certs = (List<X509Certificate>) factory.engineGenerateCertificates(nodes);
+        Assert.notNull(certs);
+        certs.stream().forEach(c -> {
+            System.out.println(c.getSubjectDN());
+            try {
+                System.out.println(NodeMgrTools.getCertFingerPrint(c.getEncoded()));
+            } catch (CertificateEncodingException e) {
+                e.printStackTrace();
+            }
+        });
     }
 }

--- a/src/test/java/node/mgr/test/cert/ImportCertTest.java
+++ b/src/test/java/node/mgr/test/cert/ImportCertTest.java
@@ -33,7 +33,7 @@ import static com.webank.webase.node.mgr.base.tools.CertTools.byteToHex;
 /**
  * test load non-guomi cert
  */
-public class importCertTest {
+public class ImportCertTest {
     private final static String head = "-----BEGIN CERTIFICATE-----\n" ;
     private final static String tail = "-----END CERTIFICATE-----\n" ;
 

--- a/src/test/java/node/mgr/test/cert/LoadGmCertTest.java
+++ b/src/test/java/node/mgr/test/cert/LoadGmCertTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2014-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package node.mgr.test.cert;
+
+import com.webank.webase.node.mgr.base.tools.CertTools;
+import com.webank.webase.node.mgr.base.tools.NodeMgrTools;
+import com.webank.webase.node.mgr.cert.CertService;
+import io.jsonwebtoken.lang.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+
+public class LoadGmCertTest extends TestBase{
+    @Autowired
+    CertService certService;
+
+    public final static String gmNodeCrt = "MIIBfDCCASKgAwIBAgIJAI98D486PmWFMAoGCCqBHM9VAYN1MDYxDzANBgNVBAMM\nBmFnZW5jeTESMBAGA1UECgwJZmlzY29iY29zMQ8wDQYDVQQLDAZhZ2VuY3kwHhcN\nMTkxMTI1MDM0MTExWhcNMjkxMTIyMDM0MTExWjA1MQ4wDAYDVQQDDAVub2RlMDES\nMBAGA1UECgwJZmlzY29iY29zMQ8wDQYDVQQLDAZhZ2VuY3kwWTATBgcqhkjOPQIB\nBggqgRzPVQGCLQNCAAS0TE9xO0C2ftL52uLvIIgIt/MREu/hqCLeBGYE/gu9/99G\nt8DPHKmqRodS1RSVjLYDZwptNFx4+v9uadgl6FG4oxowGDAJBgNVHRMEAjAAMAsG\nA1UdDwQEAwIGwDAKBggqgRzPVQGDdQNIADBFAiEAqF6J+H31mW0vcbGxFBjAM2Ue\n9GFZNrpS5UjFRDxFAcsCIFuzUNWBo/y1ySxSftxBFPd5I/iHedSFKPybcxQilvqt";
+
+    /**
+     * load guomi cert: need yml's encryptType: 0 -> 1
+     * @throws CertificateEncodingException
+     */
+    @Test
+    public void testLoadCert() throws CertificateEncodingException {
+        String crtContent = CertTools.addCertHeadAndTail(gmNodeCrt);
+        X509Certificate certificate = certService.loadSingleCertFromCrtContent(crtContent);
+        Assert.notNull(certificate);
+        System.out.println(certificate.getSubjectDN());
+        System.out.println(NodeMgrTools.getCertFingerPrint(certificate.getEncoded()));
+    }
+}

--- a/src/test/java/node/mgr/test/cert/LoadGmCertTest.java
+++ b/src/test/java/node/mgr/test/cert/LoadGmCertTest.java
@@ -25,13 +25,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.List;
 
 public class LoadGmCertTest extends TestBase{
     @Autowired
     CertService certService;
 
     public final static String gmNodeCrt = "MIIBfDCCASKgAwIBAgIJAI98D486PmWFMAoGCCqBHM9VAYN1MDYxDzANBgNVBAMM\nBmFnZW5jeTESMBAGA1UECgwJZmlzY29iY29zMQ8wDQYDVQQLDAZhZ2VuY3kwHhcN\nMTkxMTI1MDM0MTExWhcNMjkxMTIyMDM0MTExWjA1MQ4wDAYDVQQDDAVub2RlMDES\nMBAGA1UECgwJZmlzY29iY29zMQ8wDQYDVQQLDAZhZ2VuY3kwWTATBgcqhkjOPQIB\nBggqgRzPVQGCLQNCAAS0TE9xO0C2ftL52uLvIIgIt/MREu/hqCLeBGYE/gu9/99G\nt8DPHKmqRodS1RSVjLYDZwptNFx4+v9uadgl6FG4oxowGDAJBgNVHRMEAjAAMAsG\nA1UdDwQEAwIGwDAKBggqgRzPVQGDdQNIADBFAiEAqF6J+H31mW0vcbGxFBjAM2Ue\n9GFZNrpS5UjFRDxFAcsCIFuzUNWBo/y1ySxSftxBFPd5I/iHedSFKPybcxQilvqt";
+    //guomi's sdk cert is not guomi
+    public final static String gmSdkCrt = "MIICNzCCAR+gAwIBAgIJAOCh/7JoVFs3MA0GCSqGSIb3DQEBCwUAMDcxDzANBgNV\n" +
+            "BAMMBmFnZW5jeTETMBEGA1UECgwKZmlzY28tYmNvczEPMA0GA1UECwwGYWdlbmN5\n" +
+            "MB4XDTE5MTEyNTAzNDExMVoXDTI5MTEyMjAzNDExMVowMTEMMAoGA1UEAwwDc2Rr\n" +
+            "MRMwEQYDVQQKDApmaXNjby1iY29zMQwwCgYDVQQLDANzZGswVjAQBgcqhkjOPQIB\n" +
+            "BgUrgQQACgNCAAR4U4lvTksIkcWVTVs/dzJeOXIHGOyOGlYI5Oh3S92w3N1jqY2t\n" +
+            "bCdmAxc2dMR38iaeersee4sem5yFLCetfAgUoxowGDAJBgNVHRMEAjAAMAsGA1Ud\n" +
+            "DwQEAwIF4DANBgkqhkiG9w0BAQsFAAOCAQEAr6Frxn/pLNnG3aRV+aGulXXS7kYr\n" +
+            "Tc6CIZ8O+2m758+A3rWN6GHuKEZ0kYy/h2vYjpgpezVXRElmuON/LbyX+hvBXtxY\n" +
+            "aAaTFR/OLiCJ6UiRISSnRRbvl6nClmHeZjf4gddvEqAxicKGGWxmek2FXDzxvA11\n" +
+            "h4vfNEnxatLqtlM5hSZkNIYrYCiSaXFE0w2UB4uuIoLrcfE+YR4nYxISNdSKpYjh\n" +
+            "BXwVuJgMRaQXI4njL4Rd6X+f7wA6lBJBMPmj+YWHdWTQCpUOe5yYxj7o7yEPtmJr\n" +
+            "MqZAO+R9xoTWsifsjHyD3AuUxd3bQBqojih4C89tvtww+4FDzmnC3R/4pg==";
 
     /**
      * load guomi cert: need yml's encryptType: 0 -> 1

--- a/src/test/java/node/mgr/test/cert/LoadGmCertTest.java
+++ b/src/test/java/node/mgr/test/cert/LoadGmCertTest.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 public class LoadGmCertTest extends TestBase{
     @Autowired
@@ -44,4 +45,5 @@ public class LoadGmCertTest extends TestBase{
         System.out.println(certificate.getSubjectDN());
         System.out.println(NodeMgrTools.getCertFingerPrint(certificate.getEncoded()));
     }
+
 }

--- a/src/test/java/node/mgr/test/cert/TestBase.java
+++ b/src/test/java/node/mgr/test/cert/TestBase.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2014-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package node.mgr.test.cert;
+
+import com.webank.webase.node.mgr.Application;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class)
+public class TestBase {
+}

--- a/src/test/java/node/mgr/test/cert/TestPullFrontCert.java
+++ b/src/test/java/node/mgr/test/cert/TestPullFrontCert.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-public class testPullFrontCert {
+public class TestPullFrontCert {
     @Autowired
     CertService certService;
 

--- a/src/test/java/node/mgr/test/cert/importCertTest.java
+++ b/src/test/java/node/mgr/test/cert/importCertTest.java
@@ -1,185 +1,188 @@
-///**
-// * Copyright 2014-2019 the original author or authors.
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *      http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package node.mgr.test.cert;
-//
-//import java.io.*;
-//import java.security.*;
-//import java.security.cert.*;
-//import java.util.*;
-//
-//import com.webank.webase.node.mgr.base.tools.CertTools;
-//import org.fisco.bcos.web3j.crypto.ECKeyPair;
-//import org.fisco.bcos.web3j.crypto.Keys;
-//import org.fisco.bcos.web3j.utils.Numeric;
-//import org.junit.Test;
-//import org.springframework.core.io.ClassPathResource;
-//import sun.security.ec.ECPublicKeyImpl;
-//import sun.security.x509.X509CertImpl;
-//
-//import static com.webank.webase.node.mgr.base.tools.CertTools.byteToHex;
-//
-//public class importCertTest {
-//    private final static String head = "-----BEGIN CERTIFICATE-----\n" ;
-//    private final static String tail = "-----END CERTIFICATE-----\n" ;
-//
-//
-//    @Test
-//    public void testPubAddress() throws IOException, CertificateException, IllegalAccessException, InstantiationException {
-//        /**
-//         * @param: nodeCert
-//         * 只有节点证书才是ECC椭圆曲线，获取pub的方法和区块链的一致
-//         * 其余的agency chain 的crt都是rsa方法，使用大素数方法计算，不一样
-//         */
-//        InputStream node = new ClassPathResource("online/node-single.crt").getInputStream();
-//        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-//        X509CertImpl nodeCert = (X509CertImpl) cf.generateCertificate(node);
-//        // rsa算法的公钥和ecc的不一样
-//        ECPublicKeyImpl pub = (ECPublicKeyImpl) nodeCert.getPublicKey();
-//        byte[] pubBytes = pub.getEncodedPublicValue();
-//        String publicKey = Numeric.toHexStringNoPrefix(pubBytes);
-//        String address = Keys.getAddress(publicKey);
-//        byte[] addByteArray = Keys.getAddress(pubBytes);
-//        System.out.println("byte[] : pub ");
-//        System.out.println(pubBytes);
-//        System.out.println("====================================");
-//        System.out.println(publicKey); // 04e5e7efc9e8d5bed699313d5a0cd5b024b3c11811d50473b987b9429c2f6379742c88249a7a8ea64ab0e6f2b69fb8bb280454f28471e38621bea8f38be45bc42d
-//        System.out.println("byte[] to pub to address ");
-//        System.out.println(address); // f7b2c352e9a872d37a427601c162671202416dbc
-//        System.out.println("包含开头的04");
-//        System.out.println(byteToHex(addByteArray));
-//    }
-//
-//    /**
-//     * address到底需不需要传入pub的开头的两位04
-//     * 答案： 不需要，公钥是128位的
-//     */
-//    @Test
-//    public void testAddress() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException {
-//        ECKeyPair key = Keys.createEcKeyPair();
-//        // 用byte[]穿进去获取公钥，就会可能多出一位0
-//        byte[] pubBytes = key.getPublicKey().toByteArray();
-//        System.out.println("=============原生的==============");
-//        System.out.println(key.getPublicKey()); //64bytes BigInteger
-//        System.out.println(Keys.getAddress(key.getPublicKey()));
-//
-//        System.out.println("===========通过转成hex后获取地址============");
-//        System.out.println(Numeric.toHexStringNoPrefix(key.getPublicKey())); //Hex后显示
-//        System.out.println(Keys.getAddress(Numeric.toHexStringNoPrefix(key.getPublicKey())));
-//
-//        System.out.println("===========通过byte[]============");
-//        System.out.println(Numeric.toHexStringNoPrefix(pubBytes)); // BigInteget=> byte[] => hex 多一位
-//        System.out.println(Keys.getAddress(Numeric.toHexStringNoPrefix(pubBytes)));
-//        System.out.println("===============");
-////        System.out.println(Keys.getAddress(pubBytes));
-//    }
-//
-//    @Test
-//    public void testImport() throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeyException, SignatureException, NoSuchProviderException {
-//        // read from file is
-//        InputStream pem = new ClassPathResource("agency/node.crt").getInputStream();
-//        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-//        // agency's crt
-//        List<X509CertImpl> certs = (List<X509CertImpl>) cf.generateCertificates(pem);
-//
-//
-//        for(X509CertImpl c: certs) {
-//            System.out.println(c.getSubjectDN());
-//        }
-//        X509CertImpl nodeCert = certs.get(0);
-//        X509CertImpl agencyCert = certs.get(1);
-//        X509CertImpl caCert = certs.get(2);
+/**
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package node.mgr.test.cert;
+
+import java.io.*;
+import java.security.*;
+import java.security.cert.*;
+import java.util.*;
+
+import com.webank.webase.node.mgr.base.tools.NodeMgrTools;
+import org.fisco.bcos.web3j.crypto.ECKeyPair;
+import org.fisco.bcos.web3j.crypto.Keys;
+import org.fisco.bcos.web3j.utils.Numeric;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import sun.security.ec.ECPublicKeyImpl;
+
+import static com.webank.webase.node.mgr.base.tools.CertTools.byteToHex;
+
+/**
+ * test load non-guomi cert
+ */
+public class importCertTest {
+    private final static String head = "-----BEGIN CERTIFICATE-----\n" ;
+    private final static String tail = "-----END CERTIFICATE-----\n" ;
+
+
+    @Test
+    public void testPubAddress() throws IOException, CertificateException, IllegalAccessException, InstantiationException {
+        /**
+         * @param: nodeCert
+         * 只有节点证书才是ECC椭圆曲线，获取pub的方法和区块链的一致
+         * 其余的agency chain 的crt都是rsa方法，使用大素数方法计算，不一样
+         */
+        // need crt file
+        InputStream node = new ClassPathResource("node.crt").getInputStream();
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        X509Certificate nodeCert = (X509Certificate) cf.generateCertificate(node);
+        // rsa算法的公钥和ecc的不一样
+        ECPublicKeyImpl pub = (ECPublicKeyImpl) nodeCert.getPublicKey();
+        byte[] pubBytes = pub.getEncodedPublicValue();
+        String publicKey = Numeric.toHexStringNoPrefix(pubBytes);
+        String address = Keys.getAddress(publicKey);
+        byte[] addByteArray = Keys.getAddress(pubBytes);
+        System.out.println("byte[] : pub ");
+        System.out.println(pubBytes);
+        System.out.println("====================================");
+        System.out.println(publicKey); // 04e5e7efc9e8d5bed699313d5a0cd5b024b3c11811d50473b987b9429c2f6379742c88249a7a8ea64ab0e6f2b69fb8bb280454f28471e38621bea8f38be45bc42d
+        System.out.println("byte[] to pub to address ");
+        System.out.println(address); // f7b2c352e9a872d37a427601c162671202416dbc
+        System.out.println("包含开头的04");
+        System.out.println(byteToHex(addByteArray));
+    }
+
+    /**
+     * address到底需不需要传入pub的开头的两位04
+     * 答案： 不需要，公钥是128位的
+     */
+    @Test
+    public void testAddress() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException {
+        ECKeyPair key = Keys.createEcKeyPair();
+        // 用byte[]穿进去获取公钥，就会可能多出一位0
+        byte[] pubBytes = key.getPublicKey().toByteArray();
+        System.out.println("=============原生的==============");
+        System.out.println(key.getPublicKey()); //64bytes BigInteger
+        System.out.println(Keys.getAddress(key.getPublicKey()));
+
+        System.out.println("===========通过转成hex后获取地址============");
+        System.out.println(Numeric.toHexStringNoPrefix(key.getPublicKey())); //Hex后显示
+        System.out.println(Keys.getAddress(Numeric.toHexStringNoPrefix(key.getPublicKey())));
+
+        System.out.println("===========通过byte[]============");
+        System.out.println(Numeric.toHexStringNoPrefix(pubBytes)); // BigInteget=> byte[] => hex 多一位
+        System.out.println(Keys.getAddress(Numeric.toHexStringNoPrefix(pubBytes)));
+        System.out.println("===============");
+//        System.out.println(Keys.getAddress(pubBytes));
+    }
+
+    @Test
+    public void testImport() throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeyException, SignatureException, NoSuchProviderException {
+        // read from file is
+        InputStream pem = new ClassPathResource("node.crt").getInputStream();
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        // agency's crt
+        List<X509Certificate> certs = (List<X509Certificate>) cf.generateCertificates(pem);
+
+
+        for(X509Certificate c: certs) {
+            System.out.println(c.getSubjectDN());
+        }
+        X509Certificate nodeCert = certs.get(0);
+//        X509Certificate agencyCert = certs.get(1);
+//        X509Certificate caCert = certs.get(2);
 //        //只能验证上一级
 //        agencyCert.verify(caCert.getPublicKey());
 //        nodeCert.verify(agencyCert.getPublicKey());
-//
-//        /**
-//         *  根据subjectDN 获取证书类型，证书名字
-//         */
-//
-//    }
-//
-//    @Test
-//    public void getSingleCrtContent() throws IOException {
-//        // read from file is
-//        InputStream pem = new ClassPathResource("agency/node.crt").getInputStream();
-//        String certContent = getString(pem);
-//        List<String> list = new ArrayList<>();
-//        String[] nodeCrtStrArray = certContent.split(head);
-//        for(int i = 0; i < nodeCrtStrArray.length; i++) {
-//            String[] nodeCrtStrArray2 = nodeCrtStrArray[i].split(tail);
-//            for(int j = 0; j < nodeCrtStrArray2.length; j++) {
-//                String ca = nodeCrtStrArray2[j];
-//                if(ca.length() != 0) {
-//                    list.add(formatStr(ca));
-//                }
-//            }
+
+        /**
+         *  根据subjectDN 获取证书类型，证书名字
+         */
+
+    }
+
+    @Test
+    public void getSingleCrtContent() throws IOException {
+        // read from file is
+        InputStream pem = new ClassPathResource("node.crt").getInputStream();
+        String certContent = getString(pem);
+        List<String> list = new ArrayList<>();
+        String[] nodeCrtStrArray = certContent.split(head);
+        for(int i = 0; i < nodeCrtStrArray.length; i++) {
+            String[] nodeCrtStrArray2 = nodeCrtStrArray[i].split(tail);
+            for(int j = 0; j < nodeCrtStrArray2.length; j++) {
+                String ca = nodeCrtStrArray2[j];
+                if(ca.length() != 0) {
+                    list.add(formatStr(ca));
+                }
+            }
+        }
+        for(String s: list) {
+            System.out.println(s);
+            System.out.println();
+        }
+    }
+    public static String formatStr(String string) {
+        return string.substring(0, string.length() - 1);
+    }
+    public static String getString(InputStream inputStream) throws IOException {
+        byte[] bytes = new byte[0];
+        bytes = new byte[inputStream.available()];
+        inputStream.read(bytes);
+        String str = new String(bytes);
+        return str;
+    }
+
+    public String getFingerPrint(X509Certificate cert)throws Exception {
+        // 指纹
+        /**
+         * Microsoft's presentation of certificates is a bit misleading
+         * because it presents the fingerprint as if it was contained in the certificate
+         * but actually Microsoft has to calculate the fingerprint, too.
+         * This is especially misleading because a certificate actually has many fingerprints,
+         * and Microsoft only displays the fingerprint it seems to use internally, i.e. the SHA-1 fingerprint.
+         */
+        String finger = NodeMgrTools.getCertFingerPrint(cert.getEncoded());
+        System.out.println("指纹");
+        System.out.println(finger);
+        return finger;
+//        private static String getThumbprint(X509Certificate cert)
+//            throws NoSuchAlgorithmException, CertificateEncodingException {
+//            MessageDigest md = MessageDigest.getInstance("SHA-1");
+//            byte[] der = cert.getEncoded();
+//            md.update(der);
+//            byte[] digest = md.digest();
+//            String digestHex = DatatypeConverter.printHexBinary(digest);
+//            return digestHex.toLowerCase();
 //        }
-//        for(String s: list) {
-//            System.out.println(s);
-//            System.out.println();
-//        }
-//    }
-//    public static String formatStr(String string) {
-//        return string.substring(0, string.length() - 1);
-//    }
-//    public static String getString(InputStream inputStream) throws IOException {
-//        byte[] bytes = new byte[0];
-//        bytes = new byte[inputStream.available()];
-//        inputStream.read(bytes);
-//        String str = new String(bytes);
-//        return str;
-//    }
-//
-//    public String getFingerPrint(X509CertImpl cert)throws Exception {
-//        // 指纹
-//        /**
-//         * Microsoft's presentation of certificates is a bit misleading
-//         * because it presents the fingerprint as if it was contained in the certificate
-//         * but actually Microsoft has to calculate the fingerprint, too.
-//         * This is especially misleading because a certificate actually has many fingerprints,
-//         * and Microsoft only displays the fingerprint it seems to use internally, i.e. the SHA-1 fingerprint.
-//         */
-//        String finger = cert.getFingerprint("SHA-1");
-//        System.out.println("指纹");
-//        System.out.println(finger);
-//        return finger;
-////        private static String getThumbprint(X509Certificate cert)
-////            throws NoSuchAlgorithmException, CertificateEncodingException {
-////            MessageDigest md = MessageDigest.getInstance("SHA-1");
-////            byte[] der = cert.getEncoded();
-////            md.update(der);
-////            byte[] digest = md.digest();
-////            String digestHex = DatatypeConverter.printHexBinary(digest);
-////            return digestHex.toLowerCase();
-////        }
-//    }
-//
-//    public static boolean isExpired2(X509Certificate cert) {
-//        try {
-//            cert.checkValidity();
-//            return false;
-//        } catch (CertificateExpiredException e) {
-//            System.out.println("Certificate Expired");
-//            return true;
-//        } catch (CertificateNotYetValidException e) {
-//            System.out.println("Certificate Not Yet Valid");
-//            return true;
-//        } catch (Exception e) {
-//            System.out.println("Error checking Certificate Validity.  See admin.");
-//            return true;
-//        }
-//    }
-//}
+    }
+
+    public static boolean isExpired2(X509Certificate cert) {
+        try {
+            cert.checkValidity();
+            return false;
+        } catch (CertificateExpiredException e) {
+            System.out.println("Certificate Expired");
+            return true;
+        } catch (CertificateNotYetValidException e) {
+            System.out.println("Certificate Not Yet Valid");
+            return true;
+        } catch (Exception e) {
+            System.out.println("Error checking Certificate Validity.  See admin.");
+            return true;
+        }
+    }
+}

--- a/src/test/java/node/mgr/test/frontgroupmap/FrontGroupMapServiceTest.java
+++ b/src/test/java/node/mgr/test/frontgroupmap/FrontGroupMapServiceTest.java
@@ -11,43 +11,40 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package node.mgr.test.Scheduler;
+package node.mgr.test.frontgroupmap;
 
+import com.alibaba.fastjson.JSON;
 import com.webank.webase.node.mgr.Application;
-import com.webank.webase.node.mgr.scheduler.PullBlockInfoTask;
-import com.webank.webase.node.mgr.scheduler.ResetGroupListTask;
-import com.webank.webase.node.mgr.scheduler.TransMonitorTask;
+import com.webank.webase.node.mgr.frontgroupmap.FrontGroupMapService;
+import com.webank.webase.node.mgr.frontgroupmap.entity.FrontGroup;
+import com.webank.webase.node.mgr.frontgroupmap.entity.MapListParam;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-public class SchedulerServiceTest {
+public class FrontGroupMapServiceTest {
 
     @Autowired
-    private PullBlockInfoTask pullBlockInfoTask;
-    @Autowired
-    private ResetGroupListTask resetGroupListTask;
-    @Autowired
-    private TransMonitorTask transMonitorTask;
+    private FrontGroupMapService frontGroupMapService;
 
     @Test
-    public void pullBlockInfoTaskTest() {
-        pullBlockInfoTask.pullBlockStart();
+    public void getListTest() {
+        MapListParam param = new MapListParam();
+        param.setGroupId(2);
+        List<FrontGroup> list = frontGroupMapService.getList(param);
+        assert (list != null);
+        System.out.println(JSON.toJSONString(list));
     }
 
     @Test
-    public void resetGroupListTest() {
-        resetGroupListTask.resetGroupList();
+    public void listByGroupIdTest() {
+        List<FrontGroup> list = frontGroupMapService.listByGroupId(2);
+        assert (list != null);
+        System.out.println(JSON.toJSONString(list));
     }
-
-    @Test
-    public void transMonitorTest() {
-        transMonitorTask.monitorStart();
-    }
-
 }

--- a/src/test/java/node/mgr/test/precompiled/TestSol2Abi.java
+++ b/src/test/java/node/mgr/test/precompiled/TestSol2Abi.java
@@ -19,7 +19,7 @@ import org.bouncycastle.crypto.digests.KeccakDigest;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.junit.Test;
 
-public class testSol2Abi {
+public class TestSol2Abi {
 
     // according to web3sdk
     @Test

--- a/src/test/java/node/mgr/test/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/node/mgr/test/scheduler/SchedulerServiceTest.java
@@ -11,40 +11,43 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package node.mgr.test.FrontGroupMap;
+package node.mgr.test.scheduler;
 
-import com.alibaba.fastjson.JSON;
 import com.webank.webase.node.mgr.Application;
-import com.webank.webase.node.mgr.frontgroupmap.FrontGroupMapService;
-import com.webank.webase.node.mgr.frontgroupmap.entity.FrontGroup;
-import com.webank.webase.node.mgr.frontgroupmap.entity.MapListParam;
-import java.util.List;
+import com.webank.webase.node.mgr.scheduler.PullBlockInfoTask;
+import com.webank.webase.node.mgr.scheduler.ResetGroupListTask;
+import com.webank.webase.node.mgr.scheduler.TransMonitorTask;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-public class FrontGroupMapServiceTest {
+public class SchedulerServiceTest {
 
     @Autowired
-    private FrontGroupMapService frontGroupMapService;
+    private PullBlockInfoTask pullBlockInfoTask;
+    @Autowired
+    private ResetGroupListTask resetGroupListTask;
+    @Autowired
+    private TransMonitorTask transMonitorTask;
 
     @Test
-    public void getListTest() {
-        MapListParam param = new MapListParam();
-        param.setGroupId(2);
-        List<FrontGroup> list = frontGroupMapService.getList(param);
-        assert (list != null);
-        System.out.println(JSON.toJSONString(list));
+    public void pullBlockInfoTaskTest() {
+        pullBlockInfoTask.pullBlockStart();
     }
 
     @Test
-    public void listByGroupIdTest() {
-        List<FrontGroup> list = frontGroupMapService.listByGroupId(2);
-        assert (list != null);
-        System.out.println(JSON.toJSONString(list));
+    public void resetGroupListTest() {
+        resetGroupListTask.resetGroupList();
     }
+
+    @Test
+    public void transMonitorTest() {
+        transMonitorTask.monitorStart();
+    }
+
 }


### PR DESCRIPTION
- use bouncy castle's `X509Certificate` to replace `sun.security.x509.X509CertImpl`, eliminate warning when compiling;
- increase checkNodeStatus interval from `5s` to `7.5s`;
- support guomi version's double cert machanism: 
  - load sdk's cert individually;
  - add node_encrypt cert