### PR TITLE
Update ContractMapper.xml

### DIFF
--- a/src/main/resources/mapper/ContractMapper.xml
+++ b/src/main/resources/mapper/ContractMapper.xml
@@ -129,7 +129,7 @@
       and group_id = #{groupId}
     </if>
     <if test="contractName != null and contractName != ''">
-      and contract_name like CONCAT('%',#{contractName},'%')
+      and lower(contract_name) like CONCAT('%',lower(#{contractName}),'%')
     </if>
     <if test="contractAddress != null and contractAddress != ''">
       and contract_address = #{contractAddress}
@@ -171,7 +171,7 @@
       and contract_status = #{contractStatus}
     </if>
     <if test="contractName != null and contractName != ''">
-      and contract_name = #{contractName}
+      and lower(contract_name) like CONCAT('%',lower(#{contractName}),'%')
     </if>
     <if test="account != null and account != ''">
       and account = #{account}


### PR DESCRIPTION
合约列表菜单按照合约名匹配查询时，sql语句查询条件不一致，导致查询为空。