### PR TITLE
host/add接口未检测用户输入的合法性，直接传入程序中调用系统命令的函数如：system().eval(),exec()，可能会导致攻…

### DIFF
--- a/src/main/java/com/webank/webase/node/mgr/base/tools/ValidateUtil.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/ValidateUtil.java
@@ -25,6 +25,8 @@ public class ValidateUtil {
     public static final String IP_PATTERN =
             "^((0|1\\d?\\d?|2[0-4]?\\d?|25[0-5]?|[3-9]\\d?)\\.){3}(0|1\\d?\\d?|2[0-4]?\\d?|25[0-5]?|[3-9]\\d?)$";
 
+    public static final String DOMAIN_PATTERN = "^(?=^.{3,255}$)[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+$";
+
     public static final String AGENCY_NAME_PATTERN = "^[0-9a-zA-Z_]+$";
 
     /**

--- a/src/main/java/com/webank/webase/node/mgr/base/tools/ValidateUtil.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/tools/ValidateUtil.java
@@ -25,8 +25,6 @@ public class ValidateUtil {
     public static final String IP_PATTERN =
             "^((0|1\\d?\\d?|2[0-4]?\\d?|25[0-5]?|[3-9]\\d?)\\.){3}(0|1\\d?\\d?|2[0-4]?\\d?|25[0-5]?|[3-9]\\d?)$";
 
-    public static final String DOMAIN_PATTERN = "^(?=^.{3,255}$)[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+$";
-
     public static final String AGENCY_NAME_PATTERN = "^[0-9a-zA-Z_]+$";
 
     /**

--- a/src/main/java/com/webank/webase/node/mgr/deploy/controller/HostController.java
+++ b/src/main/java/com/webank/webase/node/mgr/deploy/controller/HostController.java
@@ -80,7 +80,7 @@ public class HostController extends BaseController {
     public BaseResponse addHost(@RequestBody @Valid ReqAddHost reqAddHost, BindingResult result) throws NodeMgrException {
         checkBindResult(result);
 
-        if(!ValidateUtil.ipv4Valid(reqAddHost.getSshIp()) && !ValidateUtil.domainValid(reqAddHost.getSshIp())){
+        if(!ValidateUtil.ipv4Valid(reqAddHost.getSshIp())) {
             throw new ParamException(
                     ConstantCode.IP_FORMAT_ERROR.getCode(), ConstantCode.IP_FORMAT_ERROR.getMessage()
             );

--- a/src/main/java/com/webank/webase/node/mgr/deploy/controller/HostController.java
+++ b/src/main/java/com/webank/webase/node/mgr/deploy/controller/HostController.java
@@ -19,8 +19,10 @@ import com.webank.webase.node.mgr.base.controller.BaseController;
 import com.webank.webase.node.mgr.base.entity.BaseResponse;
 import com.webank.webase.node.mgr.base.enums.HostStatusEnum;
 import com.webank.webase.node.mgr.base.exception.NodeMgrException;
+import com.webank.webase.node.mgr.base.exception.ParamException;
 import com.webank.webase.node.mgr.base.properties.ConstantProperties;
 import com.webank.webase.node.mgr.base.tools.JsonTools;
+import com.webank.webase.node.mgr.base.tools.ValidateUtil;
 import com.webank.webase.node.mgr.deploy.entity.ReqAddHost;
 import com.webank.webase.node.mgr.deploy.entity.ReqCheckHost;
 import com.webank.webase.node.mgr.deploy.entity.TbHost;
@@ -77,6 +79,13 @@ public class HostController extends BaseController {
     @PreAuthorize(ConstantProperties.HAS_ROLE_ADMIN)
     public BaseResponse addHost(@RequestBody @Valid ReqAddHost reqAddHost, BindingResult result) throws NodeMgrException {
         checkBindResult(result);
+
+        if(!ValidateUtil.ipv4Valid(reqAddHost.getSshIp()) && !ValidateUtil.domainValid(reqAddHost.getSshIp())){
+            throw new ParamException(
+                    ConstantCode.IP_FORMAT_ERROR.getCode(), ConstantCode.IP_FORMAT_ERROR.getMessage()
+            );
+        }
+
         Instant startTime = Instant.now();
         log.info("Start addHost:[{}], start:[{}]", JsonTools.toJSONString(reqAddHost), startTime);
         try {


### PR DESCRIPTION
…击者通过构造恶意参数，在服务器上执行任意命令。例如sshIp参数payload为|echo 137284974826860，在返回的页面中存在137284974826860,所以漏洞是存在的。我的修改是在接口中验证sshIp为ipv4地址或者域名